### PR TITLE
Annotate docker commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,25 @@ import scala.concurrent.ExecutionContext.Implicits.global
 val tb = tugboat.Client()
 
 // search the sea of docker images for something that looks like a ship
+// $ docker search ship
 tb.images.search.term("ship")().map(_.map(_.name)).onComplete(println)
 
 // list the images docked at your station
+// $ docker images
 tb.images.list().map(_.map(_.id)).onComplete(println)
 
 // be your own shipping port
 
 // usher a ship out to sea
-import tugboat.Build
+// $ docker build -t ssScala path/to/dir/Dockerfile/is/in
+import tugboat.Build 
 tb.images.build(new java.io.File("path/to/dir/Dockerfile/is/in")).tag("ssScala").stream {
   case Build.Progress(prog)   => println(prog)
   case Build.Error(err, _, _) => println(err)
 }
 
 // usher foreign ships into harbor
+// $ docker pull captain/ship
 import tugboat.Pull
 tb.images.pull("captain/ship").stream {
   case Pull.Status(msg) => println(msg)
@@ -46,11 +50,13 @@ tb.images.pull("captain/ship").stream {
 
 
 // verify with the admiral that your captain credentials are still respectable
+// $ docker login -u username -p password -e email
 import tugboat.AuthConfig
 val auth = AuthConfig(user, password, email)
 tb.auth(auth)().onComplete(println)
 
 // announce your captainship when issuing orders to the crew
+// $ docker pull internalregistry.com/captain/ship
 tb.as(auth).images.pull("captain/ship").registry("internalregistry.com").stream {
   case Pull.Status(msg) => println(msg)
   case Pull.Progress(msg, _, details) =>
@@ -62,6 +68,7 @@ tb.as(auth).images.pull("captain/ship").registry("internalregistry.com").stream 
 }
 
 // fashion a new boat from a dependable stack of material and start the engines
+// $ docker run -p 80:80 captain/ship
 (for {
   container <- tb.containers.create("captain/ship")()
   run       <- tb.containers.get(container.id).start.bind(
@@ -70,25 +77,31 @@ tb.as(auth).images.pull("captain/ship").registry("internalregistry.com").stream 
 } yield container.id).onComplete(println)
 
 // produce a roster of ships out to sea
+// $ docker ps
 tb.containers.list().map(_.map(_.id)).onComplete(println)
 
 // anchor to a live boat
 val ship = tb.containers.get(id)
 
 // inspect the boat
+// $ docker inspect ship
 ship().onComplete(println)
 
 // fetch the the captains logs
+// $ docker logs ship
 ship.logs.follow(true).stdout(true).stderr(true).stream(println)
 
 // stop the boat after 5 seconds
+// $ docker stop ship
 import scala.concurrent.duration._
 ship.stop(5.seconds)().onComplete(println)
 
 // restart the boat in 5 second
+// $ docker restart ship
 ship.restart(5.seconds)().onComplete(println)
 
 // retire the ship
+// $ docker rm ship
 ship.destroy.force(true)().onComplete(println)
 ```
 


### PR DESCRIPTION
Hello Doug! Thanks very much for this library. 

However although I appreciate the Tugboat whimsy I also found it a little confusing. One thing that helped me understand was just annotating the README with docker commands as well. This made things instantly clearer. 

So I wondered if you would consider incorporating this, without losing the whimsy?

I am not quite sure of the "announce your captainship when issuing orders to the crew" one, you may want to check that?

Best wishes!
