### PR TITLE
Fix null provider config

### DIFF
--- a/src/main/scala/Docker.scala
+++ b/src/main/scala/Docker.scala
@@ -166,7 +166,9 @@ object Docker {
           )
         val http0 = new Http().configure { builder =>
           val config = builder.build()
-          val updatedProvider = config.getAsyncHttpProviderConfig match {
+          val currentProvider = Option(config.getAsyncHttpProviderConfig)
+            .getOrElse(new NettyAsyncHttpProviderConfig())
+          val updatedProvider = currentProvider match {
             case netty: NettyAsyncHttpProviderConfig =>
               netty.addProperty(
                 NettyAsyncHttpProviderConfig.SOCKET_CHANNEL_FACTORY,


### PR DESCRIPTION
* Defaults to NettyAsyncHttpProviderConfig which
  can be made to use unix sockets

Looks like this is null by default when running outside of SBT.