### PR TITLE
Upgraded to Dispatch 0.11.3 and Async HTTP Client 1.9.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ libraryDependencies ++= Seq(
   "com.github.jnr" % "jnr-unixsocket" % "0.3",
   "org.bouncycastle" % "bcprov-jdk16" % "1.46",
 //  "org.bouncycastle" % "bcpg-jdk15on" % "1.51",
-  "net.databinder.dispatch" %% "dispatch-json4s-native" % "0.11.2",
+  "net.databinder.dispatch" %% "dispatch-json4s-native" % "0.11.3",
   "org.kamranzafar" % "jtar" % "2.2",
   "me.lessis" %% "unisockets-netty" % "0.1.0",
   "org.slf4j" % "slf4j-log4j12" % "1.6.2") // testing/debugging

--- a/src/main/scala/Docker.scala
+++ b/src/main/scala/Docker.scala
@@ -168,10 +168,7 @@ object Docker {
           val config = builder.build()
           val updatedProvider = config.getAsyncHttpProviderConfig match {
             case netty: NettyAsyncHttpProviderConfig =>
-              netty.addProperty(
-                NettyAsyncHttpProviderConfig.SOCKET_CHANNEL_FACTORY,
-                sockets
-              )
+              netty.setSocketChannelFactory(sockets)
               netty.setNettyTimer(timer)
               netty
             case dunno =>


### PR DESCRIPTION
- Netty provider config uses named setters now
- SSLEngineFactory is Netty provider specific

See migration guide: https://github.com/AsyncHttpClient/async-http-client/blob/master/MIGRATION.md